### PR TITLE
Fixes padding around team members role in mobile

### DIFF
--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -28,4 +28,9 @@ const SRole = styled.div.attrs({
   text-align: center;
   letter-spacing: 1px;
   text-transform: uppercase;
+  padding: 0px 10px;
+
+   @media(min-width: 480px){
+    padding: 0px 0px;
+  }
 `


### PR DESCRIPTION
Before: 
![before](https://user-images.githubusercontent.com/24925905/56979022-b8a76c80-6b70-11e9-84ef-ab308462bea3.png)

After:
![after](https://user-images.githubusercontent.com/24925905/56979028-bc3af380-6b70-11e9-8373-23b2a70f5fd6.png)
